### PR TITLE
Add OpenAPI spec and storage layer tests

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1,0 +1,1219 @@
+openapi: "3.0.3"
+info:
+  title: Gemini OCR+Annotation PWA API
+  description: |
+    Backend API for a mobile-first PWA that uses Gemini Flash for OCR and
+    contextual annotations of Japanese text. Users scan book pages, convert
+    content to digital text via OCR, and interactively highlight words or
+    sentences to receive contextual explanations.
+  version: "1.0.0"
+  contact:
+    name: Gemini Hackathon Team
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+tags:
+  - name: Health
+    description: Service health checks
+  - name: Auth
+    description: Google OAuth 2.0 authentication
+  - name: Users
+    description: User profile and preferences
+  - name: Scans
+    description: Image upload and OCR processing
+  - name: AI
+    description: Text analysis and speech synthesis via Gemini
+  - name: Annotations
+    description: Saved annotation management
+
+security: []
+
+paths:
+  /healthz:
+    get:
+      tags: [Health]
+      summary: Health check
+      description: Returns a simple health status to verify the service is running.
+      operationId: healthCheck
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
+
+  /v1/auth/google/state:
+    get:
+      tags: [Auth]
+      summary: Get Google OAuth URL
+      description: |
+        Generates an OAuth 2.0 state token, stores it in Redis, and returns
+        the full Google SSO redirect URL for the client to navigate to.
+      operationId: getGoogleAuthState
+      responses:
+        "200":
+          description: OAuth redirect URL generated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GoogleStateResponse"
+              example:
+                ssoRedirection: "https://accounts.google.com/o/oauth2/v2/auth?client_id=...&state=abc123"
+        "500":
+          description: Failed to store state in Redis
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Internal server error
+
+  /v1/auth/google/callback:
+    get:
+      tags: [Auth]
+      summary: Server-side OAuth redirect
+      description: |
+        Handles the redirect from Google after the user authorizes the
+        application. Redirects the browser to the frontend callback URL
+        with the authorization code and state as query parameters.
+      operationId: googleCallbackRedirect
+      parameters:
+        - name: state
+          in: query
+          required: true
+          description: OAuth state token for CSRF protection
+          schema:
+            type: string
+        - name: code
+          in: query
+          required: true
+          description: Authorization code from Google
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirects to the frontend callback URL
+          headers:
+            Location:
+              description: Frontend callback URL with state and code parameters
+              schema:
+                type: string
+        "400":
+          description: Missing state or code parameter
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Missing state or code
+    post:
+      tags: [Auth]
+      summary: Client-side OAuth token exchange
+      description: |
+        Exchanges the Google authorization code for a JWT access token.
+        Validates the OAuth state against Redis, exchanges the code with
+        Google, retrieves user info, creates or retrieves the user record,
+        and returns a signed JWT.
+      operationId: googleCallbackExchange
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GoogleCallbackRequest"
+            example:
+              code: "4/0AX4XfWh..."
+              state: "abc123def456"
+      responses:
+        "200":
+          description: Token exchange successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GoogleCallbackResponse"
+              example:
+                token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                expirySeconds: 86400
+                expiresAt: "2026-03-13T12:00:00Z"
+        "400":
+          description: Invalid request body, missing code/state, or invalid state
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Code is required
+        "500":
+          description: Failed to exchange code or generate token
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Failed to exchange code
+
+  /v1/users/me:
+    get:
+      tags: [Users]
+      summary: Get user profile
+      description: Returns the authenticated user's profile information.
+      operationId: getUserProfile
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        "200":
+          description: User profile retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetUserProfileResponse"
+              example:
+                preferredLanguage: "ID"
+        "401":
+          description: Unauthorized - missing or invalid token
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Unauthorized
+        "404":
+          description: User not found
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: User not found
+    patch:
+      tags: [Users]
+      summary: Update user preferences
+      description: |
+        Updates the authenticated user's preferences. Currently supports
+        changing the preferred language for annotation explanations.
+        Valid languages are: ID (Indonesian), JP (Japanese), EN (English).
+      operationId: updateUserPreferences
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateUserPreferencesRequest"
+            example:
+              preferredLanguage: "EN"
+      responses:
+        "200":
+          description: Preferences updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateUserPreferencesResponse"
+              example:
+                preferredLanguage: "EN"
+        "400":
+          description: Invalid request body or unsupported language
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Invalid language
+        "401":
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Unauthorized
+
+  /v1/users/me/languages:
+    get:
+      tags: [Users]
+      summary: List supported languages
+      description: Returns the list of supported languages for annotation explanations.
+      operationId: getLanguages
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Languages retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetLanguagesResponse"
+              example:
+                languages:
+                  - caption: "ID"
+                    imageUrl: "https://flagcdn.com/w40/id.png"
+                  - caption: "JP"
+                    imageUrl: "https://flagcdn.com/w40/jp.png"
+                  - caption: "EN"
+                    imageUrl: "https://flagcdn.com/w40/gb.png"
+
+  /v1/scans:
+    post:
+      tags: [Scans]
+      summary: Upload image for OCR
+      description: |
+        Uploads an image file for OCR processing. The image is saved to
+        storage and OCR processing is started asynchronously in the
+        background via Gemini Flash. Supported formats: JPEG, PNG, WebP.
+      operationId: createScan
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  type: string
+                  format: binary
+                  description: Image file (JPEG, PNG, or WebP)
+      responses:
+        "201":
+          description: Scan created, OCR processing started in background
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateScanResponse"
+              example:
+                scanId: 42
+                fullText: ""
+                imageUrl: "/uploads/42.jpg"
+        "400":
+          description: Invalid form data or image type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Bad Request"
+                message: "Invalid image type. Please use JPEG, PNG, or WebP."
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Unauthorized"
+                message: "Unauthorized"
+        "413":
+          description: File too large
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Request Entity Too Large"
+                message: "File too large. Maximum size is 10 MB."
+    get:
+      tags: [Scans]
+      summary: List scans
+      description: |
+        Returns a paginated list of scans belonging to the authenticated
+        user, ordered by creation date (newest first).
+      operationId: listScans
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page number (1-based, defaults to 1)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: size
+          in: query
+          required: false
+          description: Number of items per page (defaults to server config, max 100)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Scans retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetScansResponse"
+              example:
+                data:
+                  - id: 42
+                    imageUrl: "/uploads/42.jpg"
+                    detectedLanguage: "ja"
+                    createdAt: "2026-03-12T10:30:00Z"
+                  - id: 41
+                    imageUrl: "/uploads/41.png"
+                    createdAt: "2026-03-12T09:15:00Z"
+                meta:
+                  currentPage: 1
+                  pageSize: 20
+                  nextPage: 2
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/scans/{id}:
+    get:
+      tags: [Scans]
+      summary: Get scan details
+      description: |
+        Returns the full details of a scan including the OCR text (if
+        processing is complete) and detected language.
+      operationId: getScan
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ScanId"
+      responses:
+        "200":
+          description: Scan details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetScanResponse"
+              example:
+                id: 42
+                fullText: "Japanese text extracted by OCR..."
+                imageUrl: "/uploads/42.jpg"
+                detectedLanguage: "ja"
+                createdAt: "2026-03-12T10:30:00Z"
+        "400":
+          description: Invalid scan ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Access denied - scan belongs to another user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Forbidden"
+                message: "Access denied"
+        "404":
+          description: Scan not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Not Found"
+                message: "Scan not found"
+    delete:
+      tags: [Scans]
+      summary: Delete scan
+      description: |
+        Deletes a scan and its associated image file. The scan must belong
+        to the authenticated user.
+      operationId: deleteScan
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ScanId"
+      responses:
+        "204":
+          description: Scan deleted successfully
+        "400":
+          description: Invalid scan ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Access denied - scan belongs to another user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Scan not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/ai/analyze:
+    post:
+      tags: [AI]
+      summary: Analyze highlighted text
+      description: |
+        Sends highlighted text and its surrounding context to Gemini for
+        contextual analysis. Returns meaning, usage examples, timing,
+        word breakdown, and alternative meanings in the user's preferred
+        language.
+      operationId: analyzeText
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnalyzeRequest"
+            example:
+              textToAnalyze: "お疲れ様です"
+              context: "会議が終わった後、同僚にお疲れ様ですと言いました。"
+      responses:
+        "200":
+          description: Analysis completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyzeResponse"
+              example:
+                meaning: "Good work / Thank you for your hard work"
+                usageExample: "会議後に上司に「お疲れ様です」と挨拶した。"
+                usageTiming: "Used when greeting colleagues after work or at the end of a meeting."
+                wordBreakdown: "お (honorific prefix) + 疲れ (tiredness) + 様 (formal suffix) + です (polite copula)"
+                alternativeMeaning: "Can also be used as a casual greeting among coworkers."
+        "400":
+          description: Invalid request body or missing required field
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "textToAnalyze is required"
+        "401":
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Unauthorized
+        "500":
+          description: Failed to analyze text via Gemini
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Failed to analyze text"
+
+  /v1/ai/speech:
+    post:
+      tags: [AI]
+      summary: Text-to-speech synthesis
+      description: |
+        Synthesizes speech audio from the provided text using Gemini.
+        Returns raw audio binary data (typically WAV format).
+      operationId: synthesizeSpeech
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SpeakRequest"
+            example:
+              highlightedText: "お疲れ様です"
+              contextText: "会議が終わった後"
+              tone: "polite"
+      responses:
+        "200":
+          description: Audio synthesized successfully
+          content:
+            audio/wav:
+              schema:
+                type: string
+                format: binary
+            audio/*:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: Invalid request body or missing required field
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "highlightedText is required"
+        "401":
+          description: Unauthorized
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Unauthorized
+        "500":
+          description: Failed to synthesize speech
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Failed to synthesize speech"
+
+  /v1/annotations:
+    post:
+      tags: [Annotations]
+      summary: Create annotation
+      description: |
+        Saves an annotation with the highlighted text, context, and
+        nuance data (analysis results). Optionally linked to a scan.
+      operationId: createAnnotation
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAnnotationRequest"
+            example:
+              scanId: 42
+              highlightedText: "お疲れ様です"
+              contextText: "会議が終わった後、同僚にお疲れ様ですと言いました。"
+              nuanceData:
+                meaning: "Good work / Thank you for your hard work"
+                usageExample: "会議後に上司に「お疲れ様です」と挨拶した。"
+                usageTiming: "Used when greeting colleagues after work."
+                wordBreakdown: "お + 疲れ + 様 + です"
+                alternativeMeaning: "Casual greeting among coworkers."
+      responses:
+        "201":
+          description: Annotation created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateAnnotationResponse"
+              example:
+                annotationId: 7
+                status: "saved"
+        "400":
+          description: Invalid request body or missing required field
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Bad Request"
+                message: "highlightedText is required"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Failed to create annotation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    get:
+      tags: [Annotations]
+      summary: List annotations
+      description: |
+        Returns a paginated list of annotations belonging to the
+        authenticated user. Optionally filter by scan ID.
+      operationId: listAnnotations
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page number (1-based, defaults to 1)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: size
+          in: query
+          required: false
+          description: Number of items per page (defaults to server config, max 100)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: scanId
+          in: query
+          required: false
+          description: Filter annotations by scan ID
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Annotations retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetAnnotationsResponse"
+              example:
+                data:
+                  - id: 7
+                    highlightedText: "お疲れ様です"
+                    nuanceSummary: "Good work / Thank you for your hard work"
+                    createdAt: "2026-03-12T11:00:00Z"
+                  - id: 6
+                    highlightedText: "よろしくお願いします"
+                    nuanceSummary: "Please take care of it / Best regards"
+                    createdAt: "2026-03-12T10:45:00Z"
+                meta:
+                  currentPage: 1
+                  pageSize: 20
+                  nextPage: null
+        "400":
+          description: Invalid scanId parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Bad Request"
+                message: "scanId must be a positive integer"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /v1/annotations/{id}:
+    get:
+      tags: [Annotations]
+      summary: Get annotation details
+      description: |
+        Returns the full details of an annotation including the complete
+        nuance data. The annotation must belong to the authenticated user.
+      operationId: getAnnotation
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/AnnotationId"
+      responses:
+        "200":
+          description: Annotation details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetAnnotationResponse"
+              example:
+                id: 7
+                highlightedText: "お疲れ様です"
+                contextText: "会議が終わった後、同僚にお疲れ様ですと言いました。"
+                nuanceData:
+                  meaning: "Good work / Thank you for your hard work"
+                  usageExample: "会議後に上司に「お疲れ様です」と挨拶した。"
+                  usageTiming: "Used when greeting colleagues after work."
+                  wordBreakdown: "お + 疲れ + 様 + です"
+                  alternativeMeaning: "Casual greeting among coworkers."
+                createdAt: "2026-03-12T11:00:00Z"
+        "400":
+          description: Invalid annotation ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Access denied - annotation belongs to another user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Forbidden"
+                message: "Access denied"
+        "404":
+          description: Annotation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Not Found"
+                message: "Annotation not found"
+    delete:
+      tags: [Annotations]
+      summary: Delete annotation
+      description: |
+        Deletes an annotation. The annotation must belong to the
+        authenticated user.
+      operationId: deleteAnnotation
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/AnnotationId"
+      responses:
+        "204":
+          description: Annotation deleted successfully
+        "400":
+          description: Invalid annotation ID format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Annotation not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-token
+      description: JWT token passed via the x-token header
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token passed via the Authorization header
+
+  parameters:
+    ScanId:
+      name: id
+      in: path
+      required: true
+      description: Unique scan identifier
+      schema:
+        type: integer
+        format: int64
+        example: 42
+    AnnotationId:
+      name: id
+      in: path
+      required: true
+      description: Unique annotation identifier
+      schema:
+        type: integer
+        format: int64
+        example: 7
+
+  schemas:
+    # --- Auth schemas ---
+    GoogleStateResponse:
+      type: object
+      required:
+        - ssoRedirection
+      properties:
+        ssoRedirection:
+          type: string
+          description: Full Google OAuth 2.0 authorization URL
+
+    GoogleCallbackRequest:
+      type: object
+      required:
+        - code
+        - state
+      properties:
+        code:
+          type: string
+          description: Authorization code received from Google
+        state:
+          type: string
+          description: OAuth state token for CSRF protection
+
+    GoogleCallbackResponse:
+      type: object
+      required:
+        - token
+        - expirySeconds
+        - expiresAt
+      properties:
+        token:
+          type: string
+          description: Signed JWT access token
+        expirySeconds:
+          type: integer
+          description: Token lifetime in seconds
+          example: 86400
+        expiresAt:
+          type: string
+          format: date-time
+          description: Token expiration timestamp in RFC 3339 format
+
+    # --- User schemas ---
+    GetUserProfileResponse:
+      type: object
+      required:
+        - preferredLanguage
+      properties:
+        preferredLanguage:
+          type: string
+          description: "User's preferred language code (ID, JP, or EN)"
+          enum: [ID, JP, EN]
+
+    UpdateUserPreferencesRequest:
+      type: object
+      required:
+        - preferredLanguage
+      properties:
+        preferredLanguage:
+          type: string
+          description: "Language code to set as preferred"
+          enum: [ID, JP, EN]
+
+    UpdateUserPreferencesResponse:
+      type: object
+      required:
+        - preferredLanguage
+      properties:
+        preferredLanguage:
+          type: string
+          description: "Updated preferred language code"
+          enum: [ID, JP, EN]
+
+    Language:
+      type: object
+      required:
+        - caption
+        - imageUrl
+      properties:
+        caption:
+          type: string
+          description: Language code
+          example: "ID"
+        imageUrl:
+          type: string
+          format: uri
+          description: URL to the language flag icon
+          example: "https://flagcdn.com/w40/id.png"
+
+    GetLanguagesResponse:
+      type: object
+      required:
+        - languages
+      properties:
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+
+    # --- Scan schemas ---
+    CreateScanResponse:
+      type: object
+      required:
+        - scanId
+        - imageUrl
+      properties:
+        scanId:
+          type: integer
+          format: int64
+          description: Unique identifier for the created scan
+        fullText:
+          type: string
+          description: "OCR text (empty initially; populated asynchronously)"
+        imageUrl:
+          type: string
+          description: Relative URL path to the uploaded image
+
+    ScanListItem:
+      type: object
+      required:
+        - id
+        - imageUrl
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        imageUrl:
+          type: string
+          description: Relative URL path to the scan image
+        detectedLanguage:
+          type: string
+          nullable: true
+          description: Language detected by OCR (e.g. "ja")
+        createdAt:
+          type: string
+          format: date-time
+
+    GetScansResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ScanListItem"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    GetScanResponse:
+      type: object
+      required:
+        - id
+        - imageUrl
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        fullText:
+          type: string
+          description: Full OCR text extracted from the image
+        imageUrl:
+          type: string
+          description: Relative URL path to the scan image
+        detectedLanguage:
+          type: string
+          nullable: true
+          description: Language detected by OCR
+        createdAt:
+          type: string
+          format: date-time
+
+    # --- AI schemas ---
+    AnalyzeRequest:
+      type: object
+      required:
+        - textToAnalyze
+      properties:
+        textToAnalyze:
+          type: string
+          description: The highlighted text to analyze
+        context:
+          type: string
+          description: Surrounding context text from the scanned page
+
+    AnalyzeResponse:
+      type: object
+      required:
+        - meaning
+        - usageExample
+        - usageTiming
+        - wordBreakdown
+        - alternativeMeaning
+      properties:
+        meaning:
+          type: string
+          description: Translation and explanation in the user's preferred language
+        usageExample:
+          type: string
+          description: Example sentence demonstrating usage
+        usageTiming:
+          type: string
+          description: When and in what situation this phrase is used
+        wordBreakdown:
+          type: string
+          description: Individual word-by-word breakdown with translations
+        alternativeMeaning:
+          type: string
+          description: Alternative meanings or interpretations
+
+    SpeakRequest:
+      type: object
+      required:
+        - highlightedText
+      properties:
+        highlightedText:
+          type: string
+          description: Text to synthesize into speech
+        contextText:
+          type: string
+          description: Surrounding context for pronunciation guidance
+        tone:
+          type: string
+          description: Desired tone for the speech synthesis
+
+    # --- Annotation schemas ---
+    NuanceData:
+      type: object
+      required:
+        - meaning
+        - usageExample
+        - usageTiming
+        - wordBreakdown
+        - alternativeMeaning
+      properties:
+        meaning:
+          type: string
+          description: Translation and explanation
+        usageExample:
+          type: string
+          description: Example sentence demonstrating usage
+        usageTiming:
+          type: string
+          description: When and in what situation this phrase is used
+        wordBreakdown:
+          type: string
+          description: Word-by-word breakdown
+        alternativeMeaning:
+          type: string
+          description: Alternative meanings or interpretations
+
+    CreateAnnotationRequest:
+      type: object
+      required:
+        - highlightedText
+        - nuanceData
+      properties:
+        scanId:
+          type: integer
+          format: int64
+          description: "ID of the scan this annotation belongs to (optional)"
+        highlightedText:
+          type: string
+          description: The text that was highlighted
+        contextText:
+          type: string
+          description: Surrounding context from the scan
+        nuanceData:
+          $ref: "#/components/schemas/NuanceData"
+
+    CreateAnnotationResponse:
+      type: object
+      required:
+        - annotationId
+        - status
+      properties:
+        annotationId:
+          type: integer
+          format: int64
+          description: Unique identifier for the created annotation
+        status:
+          type: string
+          description: Creation status
+          example: "saved"
+
+    AnnotationListItem:
+      type: object
+      required:
+        - id
+        - highlightedText
+        - nuanceSummary
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        highlightedText:
+          type: string
+          description: The highlighted text
+        nuanceSummary:
+          type: string
+          description: Truncated summary of the meaning (max 100 characters)
+        createdAt:
+          type: string
+          format: date-time
+
+    GetAnnotationResponse:
+      type: object
+      required:
+        - id
+        - highlightedText
+        - nuanceData
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        highlightedText:
+          type: string
+        contextText:
+          type: string
+          description: Surrounding context text (may be empty)
+        nuanceData:
+          $ref: "#/components/schemas/NuanceData"
+        createdAt:
+          type: string
+          format: date-time
+
+    GetAnnotationsResponse:
+      type: object
+      required:
+        - data
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnnotationListItem"
+        meta:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    # --- Shared schemas ---
+    PaginationMeta:
+      type: object
+      required:
+        - currentPage
+        - pageSize
+      properties:
+        currentPage:
+          type: integer
+          description: Current page number (1-based)
+          example: 1
+        pageSize:
+          type: integer
+          description: Number of items per page
+          example: 20
+        nextPage:
+          type: integer
+          nullable: true
+          description: Next page number (null if on last page)
+        previousPage:
+          type: integer
+          nullable: true
+          description: Previous page number (null if on first page)
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          description: HTTP status text (e.g. "Bad Request", "Not Found")
+        message:
+          type: string
+          description: Human-readable error message with actionable detail

--- a/backend/internal/storage/db_test.go
+++ b/backend/internal/storage/db_test.go
@@ -1,0 +1,716 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/gemini-hackathon/app/internal/models"
+)
+
+// setupTestDB creates an in-memory SQLite database with schema applied directly
+// (bypassing RunMigrations to avoid NOW() incompatibility).
+func setupTestDB(t *testing.T) DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	schema := `
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			email VARCHAR(255) NOT NULL,
+			provider VARCHAR(50) NOT NULL,
+			provider_id VARCHAR(255) NOT NULL,
+			avatar_url TEXT,
+			preferred_language VARCHAR(10) DEFAULT 'ID',
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (provider, provider_id)
+		);
+
+		CREATE TABLE scans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+			image_url TEXT NOT NULL,
+			full_ocr_text TEXT,
+			detected_language VARCHAR(10),
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE annotations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+			scan_id BIGINT REFERENCES scans(id) ON DELETE SET NULL,
+			highlighted_text TEXT NOT NULL,
+			context_text TEXT,
+			nuance_data TEXT NOT NULL,
+			is_bookmarked BOOLEAN DEFAULT 1,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE INDEX idx_scans_user_id ON scans(user_id);
+		CREATE INDEX idx_annotations_user_id ON annotations(user_id);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	return NewPostgresDB(db)
+}
+
+func createTestUser(t *testing.T, store DB, suffix string) *models.User {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	avatarURL := "https://example.com/avatar_" + suffix + ".png"
+	user := &models.User{
+		Email:             "user_" + suffix + "@example.com",
+		Provider:          "google",
+		ProviderID:        "provider_" + suffix,
+		AvatarURL:         &avatarURL,
+		PreferredLanguage: "ID",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if err := store.CreateUser(context.Background(), user); err != nil {
+		t.Fatalf("CreateUser failed: %v", err)
+	}
+	return user
+}
+
+func createTestScan(t *testing.T, store DB, userID int64, imageURL string) *models.Scan {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	scan := &models.Scan{
+		UserID:   userID,
+		ImageURL: imageURL,
+		CreatedAt: now,
+	}
+	id, err := store.CreateScan(context.Background(), scan)
+	if err != nil {
+		t.Fatalf("CreateScan failed: %v", err)
+	}
+	scan.ID = id
+	return scan
+}
+
+// --- User Tests ---
+
+func TestCreateUser(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	avatarURL := "https://example.com/avatar.png"
+	user := &models.User{
+		Email:             "test@example.com",
+		Provider:          "google",
+		ProviderID:        "goog_123",
+		AvatarURL:         &avatarURL,
+		PreferredLanguage: "EN",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	err := store.CreateUser(ctx, user)
+	if err != nil {
+		t.Fatalf("CreateUser returned error: %v", err)
+	}
+	if user.ID == 0 {
+		t.Error("expected auto-generated ID to be non-zero")
+	}
+}
+
+func TestGetUserByEmail_Found(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	created := createTestUser(t, store, "email_found")
+
+	fetched, err := store.GetUserByEmail(ctx, created.Email)
+	if err != nil {
+		t.Fatalf("GetUserByEmail returned error: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if fetched.ID != created.ID {
+		t.Errorf("ID mismatch: got %d, want %d", fetched.ID, created.ID)
+	}
+	if fetched.Email != created.Email {
+		t.Errorf("Email mismatch: got %q, want %q", fetched.Email, created.Email)
+	}
+	if fetched.Provider != created.Provider {
+		t.Errorf("Provider mismatch: got %q, want %q", fetched.Provider, created.Provider)
+	}
+}
+
+func TestGetUserByEmail_NotFound(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	fetched, err := store.GetUserByEmail(ctx, "nonexistent@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail returned error: %v", err)
+	}
+	if fetched != nil {
+		t.Errorf("expected nil for non-existent user, got %+v", fetched)
+	}
+}
+
+func TestGetUserByProvider(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	created := createTestUser(t, store, "prov")
+
+	fetched, err := store.GetUserByProvider(ctx, created.Provider, created.ProviderID)
+	if err != nil {
+		t.Fatalf("GetUserByProvider returned error: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if fetched.ID != created.ID {
+		t.Errorf("ID mismatch: got %d, want %d", fetched.ID, created.ID)
+	}
+
+	// Not found case
+	fetched, err = store.GetUserByProvider(ctx, "github", "unknown_id")
+	if err != nil {
+		t.Fatalf("GetUserByProvider returned error: %v", err)
+	}
+	if fetched != nil {
+		t.Errorf("expected nil for non-existent provider, got %+v", fetched)
+	}
+}
+
+func TestGetUserByID(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	created := createTestUser(t, store, "byid")
+
+	fetched, err := store.GetUserByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if fetched == nil {
+		t.Fatal("expected user, got nil")
+	}
+	if fetched.Email != created.Email {
+		t.Errorf("Email mismatch: got %q, want %q", fetched.Email, created.Email)
+	}
+
+	// Not found
+	fetched, err = store.GetUserByID(ctx, 99999)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if fetched != nil {
+		t.Errorf("expected nil for non-existent ID, got %+v", fetched)
+	}
+}
+
+func TestUpdateUserLanguage(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	created := createTestUser(t, store, "lang")
+
+	err := store.UpdateUserLanguage(ctx, created.ID, "JA")
+	if err != nil {
+		t.Fatalf("UpdateUserLanguage returned error: %v", err)
+	}
+
+	fetched, err := store.GetUserByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if fetched.PreferredLanguage != "JA" {
+		t.Errorf("PreferredLanguage = %q, want %q", fetched.PreferredLanguage, "JA")
+	}
+}
+
+func TestCreateUser_AvatarNil(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	user := &models.User{
+		Email:             "noavatar@example.com",
+		Provider:          "github",
+		ProviderID:        "gh_123",
+		AvatarURL:         nil,
+		PreferredLanguage: "EN",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	if err := store.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser with nil avatar returned error: %v", err)
+	}
+
+	fetched, err := store.GetUserByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetUserByID returned error: %v", err)
+	}
+	if fetched.AvatarURL != nil {
+		t.Errorf("expected nil AvatarURL, got %v", *fetched.AvatarURL)
+	}
+}
+
+// --- Scan Tests ---
+
+func TestCreateScan(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_create")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	scan := &models.Scan{
+		UserID:   user.ID,
+		ImageURL: "/uploads/test.jpg",
+		CreatedAt: now,
+	}
+
+	id, err := store.CreateScan(ctx, scan)
+	if err != nil {
+		t.Fatalf("CreateScan returned error: %v", err)
+	}
+	if id == 0 {
+		t.Error("expected non-zero scan ID")
+	}
+}
+
+func TestGetScanByID(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_get")
+	scan := createTestScan(t, store, user.ID, "/uploads/img1.jpg")
+
+	fetched, err := store.GetScanByID(ctx, scan.ID)
+	if err != nil {
+		t.Fatalf("GetScanByID returned error: %v", err)
+	}
+	if fetched.UserID != user.ID {
+		t.Errorf("UserID = %d, want %d", fetched.UserID, user.ID)
+	}
+	if fetched.ImageURL != "/uploads/img1.jpg" {
+		t.Errorf("ImageURL = %q, want %q", fetched.ImageURL, "/uploads/img1.jpg")
+	}
+}
+
+func TestGetScanByID_NotFound(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := store.GetScanByID(ctx, 99999)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestGetScansByUserID_PaginationAndOrdering(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_list")
+
+	// Create 5 scans with different timestamps
+	for i := 0; i < 5; i++ {
+		ts := time.Date(2025, 1, 1, i, 0, 0, 0, time.UTC)
+		scan := &models.Scan{
+			UserID:    user.ID,
+			ImageURL:  "/uploads/img.jpg",
+			CreatedAt: ts,
+		}
+		if _, err := store.CreateScan(ctx, scan); err != nil {
+			t.Fatalf("CreateScan %d failed: %v", i, err)
+		}
+	}
+
+	// Page 1, size 3 - should get 3 most recent
+	scans, err := store.GetScansByUserID(ctx, user.ID, 1, 3)
+	if err != nil {
+		t.Fatalf("GetScansByUserID page 1 returned error: %v", err)
+	}
+	if len(scans) != 3 {
+		t.Fatalf("expected 3 scans on page 1, got %d", len(scans))
+	}
+	// Verify DESC ordering
+	if !scans[0].CreatedAt.After(scans[1].CreatedAt) {
+		t.Error("scans should be ordered by created_at DESC")
+	}
+
+	// Page 2, size 3 - should get remaining 2
+	scans, err = store.GetScansByUserID(ctx, user.ID, 2, 3)
+	if err != nil {
+		t.Fatalf("GetScansByUserID page 2 returned error: %v", err)
+	}
+	if len(scans) != 2 {
+		t.Fatalf("expected 2 scans on page 2, got %d", len(scans))
+	}
+
+	// Empty result for different user
+	scans, err = store.GetScansByUserID(ctx, 99999, 1, 10)
+	if err != nil {
+		t.Fatalf("GetScansByUserID for other user returned error: %v", err)
+	}
+	if len(scans) != 0 {
+		t.Errorf("expected 0 scans for non-existent user, got %d", len(scans))
+	}
+}
+
+func TestUpdateScanImageURL(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_imgurl")
+	scan := createTestScan(t, store, user.ID, "/uploads/old.jpg")
+
+	err := store.UpdateScanImageURL(ctx, scan.ID, "/uploads/new.jpg")
+	if err != nil {
+		t.Fatalf("UpdateScanImageURL returned error: %v", err)
+	}
+
+	fetched, err := store.GetScanByID(ctx, scan.ID)
+	if err != nil {
+		t.Fatalf("GetScanByID returned error: %v", err)
+	}
+	if fetched.ImageURL != "/uploads/new.jpg" {
+		t.Errorf("ImageURL = %q, want %q", fetched.ImageURL, "/uploads/new.jpg")
+	}
+}
+
+func TestUpdateScanOCR(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_ocr")
+	scan := createTestScan(t, store, user.ID, "/uploads/ocr.jpg")
+
+	err := store.UpdateScanOCR(ctx, scan.ID, "recognized text here", "ja")
+	if err != nil {
+		t.Fatalf("UpdateScanOCR returned error: %v", err)
+	}
+
+	fetched, err := store.GetScanByID(ctx, scan.ID)
+	if err != nil {
+		t.Fatalf("GetScanByID returned error: %v", err)
+	}
+	if fetched.FullOCRText == nil || *fetched.FullOCRText != "recognized text here" {
+		t.Errorf("FullOCRText = %v, want %q", fetched.FullOCRText, "recognized text here")
+	}
+	if fetched.DetectedLanguage == nil || *fetched.DetectedLanguage != "ja" {
+		t.Errorf("DetectedLanguage = %v, want %q", fetched.DetectedLanguage, "ja")
+	}
+}
+
+func TestDeleteScan(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_del")
+	scan := createTestScan(t, store, user.ID, "/uploads/del.jpg")
+
+	// Delete with correct owner
+	err := store.DeleteScan(ctx, scan.ID, user.ID)
+	if err != nil {
+		t.Fatalf("DeleteScan returned error: %v", err)
+	}
+
+	// Verify deleted
+	_, err = store.GetScanByID(ctx, scan.ID)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows after delete, got: %v", err)
+	}
+}
+
+func TestDeleteScan_WrongUser(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "scan_del_wrong")
+	scan := createTestScan(t, store, user.ID, "/uploads/wrong.jpg")
+
+	// Delete with wrong user ID
+	err := store.DeleteScan(ctx, scan.ID, 99999)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows for wrong user, got: %v", err)
+	}
+
+	// Verify scan still exists
+	fetched, err := store.GetScanByID(ctx, scan.ID)
+	if err != nil {
+		t.Fatalf("scan should still exist, GetScanByID returned error: %v", err)
+	}
+	if fetched == nil {
+		t.Error("scan should still exist after failed delete")
+	}
+}
+
+// --- Annotation Tests ---
+
+func TestCreateAnnotation_WithNuanceDataRoundTrip(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "ann_create")
+	scan := createTestScan(t, store, user.ID, "/uploads/ann.jpg")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	scanID := scan.ID
+	contextText := "full sentence context"
+	annotation := &models.Annotation{
+		UserID:          user.ID,
+		ScanID:          &scanID,
+		HighlightedText: "highlighted word",
+		ContextText:     &contextText,
+		NuanceData: models.NuanceData{
+			Meaning:            "the meaning",
+			UsageExample:       "example usage",
+			UsageTiming:        "formal",
+			WordBreakdown:      "word + breakdown",
+			AlternativeMeaning: "alt meaning",
+		},
+		IsBookmarked: true,
+		CreatedAt:    now,
+	}
+
+	id, err := store.CreateAnnotation(ctx, annotation)
+	if err != nil {
+		t.Fatalf("CreateAnnotation returned error: %v", err)
+	}
+	if id == 0 {
+		t.Error("expected non-zero annotation ID")
+	}
+
+	// Round-trip: fetch and verify NuanceData
+	fetched, err := store.GetAnnotationByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAnnotationByID returned error: %v", err)
+	}
+
+	if fetched.HighlightedText != "highlighted word" {
+		t.Errorf("HighlightedText = %q, want %q", fetched.HighlightedText, "highlighted word")
+	}
+	if fetched.ContextText == nil || *fetched.ContextText != "full sentence context" {
+		t.Errorf("ContextText = %v, want %q", fetched.ContextText, "full sentence context")
+	}
+	if fetched.ScanID == nil || *fetched.ScanID != scanID {
+		t.Errorf("ScanID = %v, want %d", fetched.ScanID, scanID)
+	}
+	if fetched.NuanceData.Meaning != "the meaning" {
+		t.Errorf("NuanceData.Meaning = %q, want %q", fetched.NuanceData.Meaning, "the meaning")
+	}
+	if fetched.NuanceData.UsageExample != "example usage" {
+		t.Errorf("NuanceData.UsageExample = %q, want %q", fetched.NuanceData.UsageExample, "example usage")
+	}
+	if fetched.NuanceData.UsageTiming != "formal" {
+		t.Errorf("NuanceData.UsageTiming = %q, want %q", fetched.NuanceData.UsageTiming, "formal")
+	}
+	if fetched.NuanceData.WordBreakdown != "word + breakdown" {
+		t.Errorf("NuanceData.WordBreakdown = %q, want %q", fetched.NuanceData.WordBreakdown, "word + breakdown")
+	}
+	if fetched.NuanceData.AlternativeMeaning != "alt meaning" {
+		t.Errorf("NuanceData.AlternativeMeaning = %q, want %q", fetched.NuanceData.AlternativeMeaning, "alt meaning")
+	}
+	if !fetched.IsBookmarked {
+		t.Error("expected IsBookmarked to be true")
+	}
+}
+
+func TestGetAnnotationByID_NotFound(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := store.GetAnnotationByID(ctx, 99999)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestGetAnnotationsByUserID_Pagination(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "ann_list")
+	scan := createTestScan(t, store, user.ID, "/uploads/annlist.jpg")
+
+	scanID := scan.ID
+
+	// Create 5 annotations with different timestamps
+	for i := 0; i < 5; i++ {
+		ts := time.Date(2025, 1, 1, i, 0, 0, 0, time.UTC)
+		ann := &models.Annotation{
+			UserID:          user.ID,
+			ScanID:          &scanID,
+			HighlightedText: "word",
+			NuanceData:      models.NuanceData{Meaning: "meaning"},
+			IsBookmarked:    false,
+			CreatedAt:       ts,
+		}
+		if _, err := store.CreateAnnotation(ctx, ann); err != nil {
+			t.Fatalf("CreateAnnotation %d failed: %v", i, err)
+		}
+	}
+
+	// Page 1, size 3
+	anns, err := store.GetAnnotationsByUserID(ctx, user.ID, 1, 3)
+	if err != nil {
+		t.Fatalf("GetAnnotationsByUserID page 1 returned error: %v", err)
+	}
+	if len(anns) != 3 {
+		t.Fatalf("expected 3 annotations on page 1, got %d", len(anns))
+	}
+	// Verify DESC ordering
+	if !anns[0].CreatedAt.After(anns[1].CreatedAt) {
+		t.Error("annotations should be ordered by created_at DESC")
+	}
+
+	// Page 2, size 3
+	anns, err = store.GetAnnotationsByUserID(ctx, user.ID, 2, 3)
+	if err != nil {
+		t.Fatalf("GetAnnotationsByUserID page 2 returned error: %v", err)
+	}
+	if len(anns) != 2 {
+		t.Fatalf("expected 2 annotations on page 2, got %d", len(anns))
+	}
+}
+
+func TestGetAnnotationsByUserIDAndScanID(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "ann_scan_filter")
+	scan1 := createTestScan(t, store, user.ID, "/uploads/s1.jpg")
+	scan2 := createTestScan(t, store, user.ID, "/uploads/s2.jpg")
+
+	scan1ID := scan1.ID
+	scan2ID := scan2.ID
+
+	// Create 3 annotations for scan1, 2 for scan2
+	for i := 0; i < 3; i++ {
+		ann := &models.Annotation{
+			UserID:          user.ID,
+			ScanID:          &scan1ID,
+			HighlightedText: "word",
+			NuanceData:      models.NuanceData{Meaning: "m"},
+			CreatedAt:       time.Now().UTC(),
+		}
+		if _, err := store.CreateAnnotation(ctx, ann); err != nil {
+			t.Fatalf("CreateAnnotation failed: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		ann := &models.Annotation{
+			UserID:          user.ID,
+			ScanID:          &scan2ID,
+			HighlightedText: "other",
+			NuanceData:      models.NuanceData{Meaning: "m"},
+			CreatedAt:       time.Now().UTC(),
+		}
+		if _, err := store.CreateAnnotation(ctx, ann); err != nil {
+			t.Fatalf("CreateAnnotation failed: %v", err)
+		}
+	}
+
+	anns, err := store.GetAnnotationsByUserIDAndScanID(ctx, user.ID, scan1ID, 1, 10)
+	if err != nil {
+		t.Fatalf("GetAnnotationsByUserIDAndScanID returned error: %v", err)
+	}
+	if len(anns) != 3 {
+		t.Errorf("expected 3 annotations for scan1, got %d", len(anns))
+	}
+
+	anns, err = store.GetAnnotationsByUserIDAndScanID(ctx, user.ID, scan2ID, 1, 10)
+	if err != nil {
+		t.Fatalf("GetAnnotationsByUserIDAndScanID returned error: %v", err)
+	}
+	if len(anns) != 2 {
+		t.Errorf("expected 2 annotations for scan2, got %d", len(anns))
+	}
+}
+
+func TestDeleteAnnotation(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "ann_del")
+	scan := createTestScan(t, store, user.ID, "/uploads/anndel.jpg")
+	scanID := scan.ID
+
+	ann := &models.Annotation{
+		UserID:          user.ID,
+		ScanID:          &scanID,
+		HighlightedText: "delete me",
+		NuanceData:      models.NuanceData{Meaning: "m"},
+		CreatedAt:       time.Now().UTC(),
+	}
+	id, err := store.CreateAnnotation(ctx, ann)
+	if err != nil {
+		t.Fatalf("CreateAnnotation failed: %v", err)
+	}
+
+	// Delete with correct owner
+	err = store.DeleteAnnotation(ctx, id, user.ID)
+	if err != nil {
+		t.Fatalf("DeleteAnnotation returned error: %v", err)
+	}
+
+	// Verify deleted
+	_, err = store.GetAnnotationByID(ctx, id)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows after delete, got: %v", err)
+	}
+}
+
+func TestDeleteAnnotation_WrongUser(t *testing.T) {
+	store := setupTestDB(t)
+	ctx := context.Background()
+
+	user := createTestUser(t, store, "ann_del_wrong")
+	scan := createTestScan(t, store, user.ID, "/uploads/annwrong.jpg")
+	scanID := scan.ID
+
+	ann := &models.Annotation{
+		UserID:          user.ID,
+		ScanID:          &scanID,
+		HighlightedText: "keep me",
+		NuanceData:      models.NuanceData{Meaning: "m"},
+		CreatedAt:       time.Now().UTC(),
+	}
+	id, err := store.CreateAnnotation(ctx, ann)
+	if err != nil {
+		t.Fatalf("CreateAnnotation failed: %v", err)
+	}
+
+	// Delete with wrong user
+	err = store.DeleteAnnotation(ctx, id, 99999)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows for wrong user, got: %v", err)
+	}
+
+	// Verify still exists
+	fetched, err := store.GetAnnotationByID(ctx, id)
+	if err != nil {
+		t.Fatalf("annotation should still exist, got error: %v", err)
+	}
+	if fetched == nil {
+		t.Error("annotation should still exist after failed delete")
+	}
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/backend/internal/storage/file_test.go
+++ b/backend/internal/storage/file_test.go
@@ -1,0 +1,167 @@
+package storage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestFileStorage(t *testing.T) (FileStorage, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	fs, err := NewLocalFileStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("NewLocalFileStorage failed: %v", err)
+	}
+	return fs, tmpDir
+}
+
+func TestSaveImage_CreatesFileAndHash(t *testing.T) {
+	fs, tmpDir := newTestFileStorage(t)
+
+	data := []byte("fake image data")
+	path, hashPtr, err := fs.SaveImage("scan_001", data, "image/jpeg")
+	if err != nil {
+		t.Fatalf("SaveImage returned error: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatalf("expected file to exist at %s", path)
+	}
+
+	// Verify path format
+	expectedPath := filepath.Join(tmpDir, "scan_001.jpg")
+	if path != expectedPath {
+		t.Errorf("path = %q, want %q", path, expectedPath)
+	}
+
+	// Verify hash correctness
+	if hashPtr == nil {
+		t.Fatal("expected non-nil hash pointer")
+	}
+	expectedHash := sha256.Sum256(data)
+	expectedHashStr := hex.EncodeToString(expectedHash[:])
+	if *hashPtr != expectedHashStr {
+		t.Errorf("hash = %q, want %q", *hashPtr, expectedHashStr)
+	}
+
+	// Verify content written correctly
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved file: %v", err)
+	}
+	if string(content) != string(data) {
+		t.Errorf("file content mismatch")
+	}
+}
+
+func TestSaveImage_MimeTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		wantExt  string
+	}{
+		{"jpeg", "image/jpeg", ".jpg"},
+		{"jpg", "image/jpg", ".jpg"},
+		{"png", "image/png", ".png"},
+		{"webp", "image/webp", ".webp"},
+		{"unknown", "application/octet-stream", ".bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs, tmpDir := newTestFileStorage(t)
+			data := []byte("data")
+			path, _, err := fs.SaveImage("test", data, tt.mimeType)
+			if err != nil {
+				t.Fatalf("SaveImage returned error: %v", err)
+			}
+			expectedPath := filepath.Join(tmpDir, "test"+tt.wantExt)
+			if path != expectedPath {
+				t.Errorf("path = %q, want %q", path, expectedPath)
+			}
+		})
+	}
+}
+
+func TestOpenImage_ReadBack(t *testing.T) {
+	fs, _ := newTestFileStorage(t)
+
+	data := []byte("read me back")
+	path, _, err := fs.SaveImage("readback", data, "image/png")
+	if err != nil {
+		t.Fatalf("SaveImage returned error: %v", err)
+	}
+
+	content, err := fs.OpenImage(path)
+	if err != nil {
+		t.Fatalf("OpenImage returned error: %v", err)
+	}
+	if string(content) != string(data) {
+		t.Errorf("content mismatch: got %q, want %q", string(content), string(data))
+	}
+}
+
+func TestOpenImage_MissingFile(t *testing.T) {
+	fs, _ := newTestFileStorage(t)
+
+	_, err := fs.OpenImage("/nonexistent/path/file.jpg")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestDeleteImage_RemovesFile(t *testing.T) {
+	fs, _ := newTestFileStorage(t)
+
+	data := []byte("delete me")
+	path, _, err := fs.SaveImage("delme", data, "image/jpeg")
+	if err != nil {
+		t.Fatalf("SaveImage returned error: %v", err)
+	}
+
+	err = fs.DeleteImage(path)
+	if err != nil {
+		t.Fatalf("DeleteImage returned error: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected file to be deleted")
+	}
+}
+
+func TestDeleteImage_NonExistentFile(t *testing.T) {
+	fs, _ := newTestFileStorage(t)
+
+	err := fs.DeleteImage("/nonexistent/path/file.jpg")
+	if err != nil {
+		t.Errorf("DeleteImage on non-existent file should not error, got: %v", err)
+	}
+}
+
+func TestGetExtensionFromMimeType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		want     string
+	}{
+		{"image/jpeg", ".jpg"},
+		{"image/jpg", ".jpg"},
+		{"image/png", ".png"},
+		{"image/webp", ".webp"},
+		{"image/gif", ".bin"},
+		{"text/plain", ".bin"},
+		{"", ".bin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			got := getExtensionFromMimeType(tt.mimeType)
+			if got != tt.want {
+				t.Errorf("getExtensionFromMimeType(%q) = %q, want %q", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/storage/migrate_test.go
+++ b/backend/internal/storage/migrate_test.go
@@ -1,0 +1,192 @@
+package storage
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// createTestMigrationsDir writes a SQLite-compatible migration file to a temp directory
+// and returns the directory path.
+func createTestMigrationsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Use SQLite-compatible syntax (no BIGSERIAL, no JSONB, no WITH TIME ZONE)
+	migration := `
+		CREATE TABLE IF NOT EXISTS users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			email VARCHAR(255) NOT NULL,
+			provider VARCHAR(50) NOT NULL,
+			provider_id VARCHAR(255) NOT NULL,
+			avatar_url TEXT,
+			preferred_language VARCHAR(10) DEFAULT 'ID',
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE (provider, provider_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS scans (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+			image_url TEXT NOT NULL,
+			full_ocr_text TEXT,
+			detected_language VARCHAR(10),
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+
+		CREATE TABLE IF NOT EXISTS annotations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
+			scan_id BIGINT REFERENCES scans(id) ON DELETE SET NULL,
+			highlighted_text TEXT NOT NULL,
+			context_text TEXT,
+			nuance_data TEXT NOT NULL,
+			is_bookmarked BOOLEAN DEFAULT 1,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		);
+	`
+	err := os.WriteFile(filepath.Join(dir, "001_schema.sql"), []byte(migration), 0644)
+	if err != nil {
+		t.Fatalf("failed to write migration file: %v", err)
+	}
+	return dir
+}
+
+func TestRunMigrations_CreatesTablesFromSQLFiles(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	migrationsDir := createTestMigrationsDir(t)
+
+	// RunMigrations will error because recordMigration uses NOW() which SQLite
+	// doesn't support. However, executeMigration commits its own transaction
+	// before recordMigration runs, so the DDL should be persisted.
+	err = RunMigrations(db, migrationsDir)
+	if err == nil {
+		t.Fatal("expected error from RunMigrations due to NOW() incompatibility with SQLite")
+	}
+
+	// Verify the migration DDL was committed despite the recording failure.
+	_, err = db.Exec("INSERT INTO users (email, provider, provider_id) VALUES ('a@b.com', 'google', 'g1')")
+	if err != nil {
+		t.Fatalf("users table should exist after migration: %v", err)
+	}
+
+	_, err = db.Exec("INSERT INTO scans (user_id, image_url) VALUES (1, '/img.jpg')")
+	if err != nil {
+		t.Fatalf("scans table should exist after migration: %v", err)
+	}
+
+	_, err = db.Exec("INSERT INTO annotations (user_id, highlighted_text, nuance_data) VALUES (1, 'text', '{}')")
+	if err != nil {
+		t.Fatalf("annotations table should exist after migration: %v", err)
+	}
+}
+
+func TestRunMigrations_IdempotentRerun(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	migrationsDir := createTestMigrationsDir(t)
+
+	// First run will fail at recordMigration (NOW() unsupported in SQLite),
+	// but executeMigration commits the DDL. Manually record the migration
+	// with SQLite-compatible SQL so the second run can test the idempotency path.
+	_ = RunMigrations(db, migrationsDir)
+
+	// Manually record the migration so isMigrationApplied returns true on rerun.
+	_, err = db.Exec(
+		"INSERT INTO schema_migrations (name, applied_at) VALUES ($1, CURRENT_TIMESTAMP)",
+		"001_schema.sql",
+	)
+	if err != nil {
+		t.Fatalf("failed to manually record migration: %v", err)
+	}
+
+	// Second run should skip the already-applied migration and succeed.
+	err = RunMigrations(db, migrationsDir)
+	if err != nil {
+		t.Errorf("second RunMigrations should succeed (migration already recorded), got: %v", err)
+	}
+}
+
+func TestRunMigrations_EmptyDirectory(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+	defer db.Close()
+
+	emptyDir := t.TempDir()
+
+	err = RunMigrations(db, emptyDir)
+	if err != nil {
+		t.Fatalf("RunMigrations with empty dir should not error, got: %v", err)
+	}
+
+	// Verify schema_migrations table was created even with no migration files
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count)
+	if err != nil {
+		t.Fatalf("schema_migrations table should exist: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 migrations recorded, got %d", count)
+	}
+}
+
+func TestReadMigrationFiles_SortsAlphabetically(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files in reverse order
+	files := []string{"003_third.sql", "001_first.sql", "002_second.sql"}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("SELECT 1;"), 0644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	migrations, err := readMigrationFiles(dir)
+	if err != nil {
+		t.Fatalf("readMigrationFiles returned error: %v", err)
+	}
+
+	if len(migrations) != 3 {
+		t.Fatalf("expected 3 migrations, got %d", len(migrations))
+	}
+	if migrations[0].Name != "001_first.sql" {
+		t.Errorf("first migration = %q, want %q", migrations[0].Name, "001_first.sql")
+	}
+	if migrations[1].Name != "002_second.sql" {
+		t.Errorf("second migration = %q, want %q", migrations[1].Name, "002_second.sql")
+	}
+	if migrations[2].Name != "003_third.sql" {
+		t.Errorf("third migration = %q, want %q", migrations[2].Name, "003_third.sql")
+	}
+}
+
+func TestReadMigrationFiles_SkipsNonSQL(t *testing.T) {
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "001_ok.sql"), []byte("SELECT 1;"), 0644)
+	os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("not a migration"), 0644)
+	os.WriteFile(filepath.Join(dir, "notes.md"), []byte("notes"), 0644)
+
+	migrations, err := readMigrationFiles(dir)
+	if err != nil {
+		t.Fatalf("readMigrationFiles returned error: %v", err)
+	}
+	if len(migrations) != 1 {
+		t.Errorf("expected 1 migration (only .sql), got %d", len(migrations))
+	}
+}

--- a/backend/internal/storage/redis_test.go
+++ b/backend/internal/storage/redis_test.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func skipIfNoRedis(t *testing.T) RedisClient {
+	t.Helper()
+	client, err := NewRedisClient("localhost:6379")
+	if err != nil {
+		t.Skip("requires Redis: " + err.Error())
+	}
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func TestRedis_SetGetDeleteState(t *testing.T) {
+	client := skipIfNoRedis(t)
+	ctx := context.Background()
+
+	state := "test_state_" + time.Now().Format("20060102150405.000")
+	sessionID := "session_abc123"
+
+	// Set
+	err := client.SetState(ctx, state, sessionID, 30*time.Second)
+	if err != nil {
+		t.Fatalf("SetState returned error: %v", err)
+	}
+
+	// Get
+	got, err := client.GetState(ctx, state)
+	if err != nil {
+		t.Fatalf("GetState returned error: %v", err)
+	}
+	if got != sessionID {
+		t.Errorf("GetState = %q, want %q", got, sessionID)
+	}
+
+	// Delete
+	err = client.DeleteState(ctx, state)
+	if err != nil {
+		t.Fatalf("DeleteState returned error: %v", err)
+	}
+
+	// Get after delete should return error (redis.Nil)
+	got, err = client.GetState(ctx, state)
+	if err == nil {
+		t.Errorf("expected error after delete, got value: %q", got)
+	}
+}
+
+func TestRedis_GetState_NonExistent(t *testing.T) {
+	client := skipIfNoRedis(t)
+	ctx := context.Background()
+
+	got, err := client.GetState(ctx, "nonexistent_key_"+time.Now().Format("20060102150405.000"))
+	if err == nil {
+		t.Errorf("expected error for non-existent key, got value: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `backend/docs/openapi.yaml` documenting all API endpoints (auth, users, scans, AI, annotations)
- Adds comprehensive test coverage for the storage package: DB, file, migration, and Redis
- Fixes import ordering in `db_test.go` to match backend CLAUDE.md conventions
- Fixes vacuous migration tests that previously passed without verifying intended behavior

## Test plan
- [x] All 47 storage tests pass (`go test ./internal/storage/`)
- [x] Migration idempotency test now actually exercises the skip-already-applied path
- [x] Import ordering follows stdlib → third-party → internal convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)