### PR TITLE
fix: satisfy scan image hook lint

### DIFF
--- a/web/src/components/scanpage/ScanImage.tsx
+++ b/web/src/components/scanpage/ScanImage.tsx
@@ -6,12 +6,16 @@ interface ScanImageProps {
   alt?: string
 }
 
+interface BlobImageState {
+  sourceUrl: string
+  blobUrl: string
+}
+
 export default function ScanImage({ imageUrl, alt = 'Scanned image' }: ScanImageProps) {
-  const [blobUrl, setBlobUrl] = useState<string>('')
+  const [blobImage, setBlobImage] = useState<BlobImageState | null>(null)
 
   useEffect(() => {
     if (!imageUrl) {
-      setBlobUrl('')
       return
     }
 
@@ -22,10 +26,10 @@ export default function ScanImage({ imageUrl, alt = 'Scanned image' }: ScanImage
       .then((blob) => {
         if (!isActive) return
         objectUrl = URL.createObjectURL(blob)
-        setBlobUrl(objectUrl)
+        setBlobImage({ sourceUrl: imageUrl, blobUrl: objectUrl })
       })
       .catch(() => {
-        if (isActive) setBlobUrl('')
+        if (isActive) setBlobImage(null)
       })
 
     return () => {
@@ -40,14 +44,14 @@ export default function ScanImage({ imageUrl, alt = 'Scanned image' }: ScanImage
     return null
   }
 
-  if (!blobUrl) {
+  if (!blobImage || blobImage.sourceUrl !== imageUrl) {
     return null
   }
 
   return (
     <div className="mb-6">
       <img
-        src={blobUrl}
+        src={blobImage.blobUrl}
         alt={alt}
         className="w-full h-auto rounded-lg border border-gray-200"
       />

--- a/web/src/components/scanpage/__tests__/ScanImage.test.tsx
+++ b/web/src/components/scanpage/__tests__/ScanImage.test.tsx
@@ -35,6 +35,15 @@ describe('ScanImage', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('should hide the previous blob when imageUrl is removed', async () => {
+    const { container, rerender } = render(<ScanImage imageUrl="/v1/scans/test-id/image" />)
+    await screen.findByRole('img')
+
+    rerender(<ScanImage imageUrl={undefined} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
   it('should revoke blob URLs on cleanup', async () => {
     const { unmount } = render(<ScanImage imageUrl="/v1/scans/test-id/image" />)
     await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled())


### PR DESCRIPTION
## What Change

- Updates `ScanImage` to track private blob URLs with the source image URL instead of a bare blob string.
- Removes the synchronous `setState` call from the effect path when `imageUrl` is empty.
- Adds a regression test that hides the previously rendered blob when `imageUrl` is removed.

## Why Change

- Fixes the GitHub Actions lint failure from `react-hooks/set-state-in-effect` in `ScanImage`.
- Preserves the no-image render behavior without triggering cascading render warnings from React hook lint rules.

## Impact

- **Affected areas:** Private scan image rendering in `web/src/components/scanpage/ScanImage.tsx`.
- **Breaking changes:** No.
- **Dependencies:** No new dependencies.
- **Testing:** `bun run lint`, `bun run test`, `bun run build`, and `bun run test:e2e`.

## Test Plan

- [x] `bun run lint`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run test:e2e`

Made with [Cursor](https://cursor.com)